### PR TITLE
Replace bitnami image references with bitnamilegacy

### DIFF
--- a/rabbitmq.yaml
+++ b/rabbitmq.yaml
@@ -147,7 +147,7 @@ nginx:
   containers:
     nginx-reverse-proxy:
       image-tag: <- $nginx-image
-      image: docker.io/bitnami/nginx
+      image: docker.io/bitnamilegacy/nginx
   variables:
     proxy-target-host:
       value: <- connection-hostname("rabbitmq")


### PR DESCRIPTION
This PR replaces 'image: docker.io/bitnami/' and 'image: bitnami/' with their 'bitnamilegacy' equivalents, as per organization migration.